### PR TITLE
Feat/add control options

### DIFF
--- a/src/__tests__/components/Marker.spec.js
+++ b/src/__tests__/components/Marker.spec.js
@@ -31,7 +31,9 @@ describe('Marker', () => {
   })
 
   it('accepts a `map` and a `google` prop', () => {
-    const wrapper = mount(<Marker google={google} map={map} />);
+    const wrapper = mount(<Marker google={google}
+                                  map={map}
+                                  position={location} />);
     expect(wrapper.props().google).to.equal(google);
     expect(wrapper.props().map).to.equal(map);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -99,11 +99,37 @@ export class Map extends React.Component {
         const mapRef = this.refs.map;
         const node = ReactDOM.findDOMNode(mapRef);
         const curr = this.state.currentLocation;
-        let center = new maps.LatLng(curr.lat, curr.lng)
+        const center = new maps.LatLng(curr.lat, curr.lng);
 
-        let mapConfig = Object.assign({}, {
-          center,
-          zoom: this.props.zoom
+        const mapTypeIds = this.props.google.maps.MapTypeId || {};
+        const mapTypeFromProps = String(this.props.mapType).toUpperCase();
+
+        const mapConfig = Object.assign({}, {
+          mapTypeId: mapTypeIds[mapTypeFromProps],
+          center: center,
+          zoom: this.props.zoom,
+          maxZoom: this.props.maxZoom,
+          minZoom: this.props.maxZoom,
+          clickableIcons: this.props.clickableIcons,
+          disableDefaultUI: this.props.disableDefaultUI,
+          zoomControl: this.props.zoomControl,
+          mapTypeControl: this.props.mapTypeControl,
+          scaleControl: this.props.scaleControl,
+          streetViewControl: this.props.streetViewControl,
+          panControl: this.props.panControl,
+          rotateControl: this.props.rotateControl,
+          scrollwheel: this.props.scrollwheel,
+          draggable: this.props.draggable,
+          keyboardShortcuts: this.props.keyboardShortcuts,
+          disableDoubleClickZoom: this.props.disableDoubleClickZoom,
+          noClear: this.props.noClear,
+          styles: this.props.styles
+        });
+
+        Object.keys(mapConfig).forEach((key) => {
+          if (!mapConfig[key]) {
+            delete mapConfig[key];
+          }
         });
 
         this.map = new maps.Map(node, mapConfig);
@@ -201,7 +227,24 @@ Map.propTypes = {
   className: T.string,
   style: T.object,
   containerStyle: T.object,
-  visible: T.bool
+  visible: T.bool,
+  mapType: T.string,
+  maxZoom: T.number,
+  minZoom: T.number,
+  clickableIcons: T.bool,
+  disableDefaultUI: T.bool,
+  zoomControl: T.bool,
+  mapTypeControl: T.bool,
+  scaleControl: T.bool,
+  streetViewControl: T.bool,
+  panControl: T.bool,
+  rotateControl: T.bool,
+  scrollwheel: T.bool,
+  draggable: T.bool,
+  keyboardShortcuts: T.bool,
+  disableDoubleClickZoom: T.bool,
+  noClear: T.bool,
+  styles: T.array
 }
 
 evtNames.forEach(e => Map.propTypes[camelize(e)] = T.func)


### PR DESCRIPTION
This adds multiple configuration options for the map.

`mapType`
`maxZoom`
The maximum zoom level which will be displayed on the map
`minZoom`
The minimum zoom level which will be displayed on the map
`clickableIcons`
When false, map icons are not clickable. A map icon represents a point of interest, also known as a POI
`disableDefaultUI`
Enables/disables all default UI. May be overridden individually.
`zoomControl`
The display options for the Zoom control
`mapTypeControl`
The initial enabled/disabled state of the Map type control
`scaleControl`
The initial enabled/disabled state of the Scale control.
`streetViewControl`
The initial enabled/disabled state of the Street View Pegman control
`panControl`
The enabled/disabled state of the Pan control.
`rotateControl`
The enabled/disabled state of the Rotate control.
`scrollwheel`
If false, disables scrollwheel zooming on the map. The scrollwheel is enabled by default.
`draggable`
If true, the object can be dragged across the map and the underlying feature will have its geometry updated.
`keyboardShortcuts`
If false, prevents the map from being controlled by the keyboard.
`disableDoubleClickZoom`
Enables/disables zoom on double click.
`noClear`
If true, do not clear the contents of the Map div.
`styles`
Styles to apply to each of the default map types. Note that for Satellite/Hybrid and Terrain modes, these styles will only apply to labels and geometry.