### PR TITLE
Add possibility to provide a language when loading Google API library

### DIFF
--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -10,9 +10,15 @@ const defaultCreateCache = (options) => {
     const apiKey = options.apiKey;
     const libraries = options.libraries || ['places'];
     const version = options.version || '3.24';
+    const language = options.language || 'en';
 
     return ScriptCache({
-        google: GoogleApi({apiKey: apiKey, libraries: libraries, version: version})
+        google: GoogleApi({
+            apiKey: apiKey,
+            language: language,
+            libraries: libraries,
+            version: version
+        })
     });
 };
 

--- a/src/lib/GoogleApi.js
+++ b/src/lib/GoogleApi.js
@@ -17,7 +17,7 @@ export const GoogleApi = function(opts) {
     let google = window.google || null;
     let loading = false;
     let channel = null;
-    let language = null;
+    let language = opts.language;
     let region = null;
 
     let onLoadEvents = [];


### PR DESCRIPTION
I live in Quebec so, most of our websites are bilingual. With this PR, we can now specify the language in which we want to load the Google API library.

```js
export default GoogleApiWrapper({
  apiKey: 'API_KEY',
  language: 'fr'
})(Container);
```