### PR TITLE
Use Google Maps API release version

### DIFF
--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -9,7 +9,7 @@ const defaultCreateCache = (options) => {
     options = options || {};
     const apiKey = options.apiKey;
     const libraries = options.libraries || ['places'];
-    const version = options.version || '3.24';
+    const version = options.version || '3';
 
     return ScriptCache({
         google: GoogleApi({apiKey: apiKey, libraries: libraries, version: version})
@@ -19,7 +19,7 @@ const defaultCreateCache = (options) => {
 export const wrapper = (options) => (WrappedComponent) => {
     const apiKey = options.apiKey;
     const libraries = options.libraries || ['places'];
-    const version = options.version || '3.24';
+    const version = options.version || '3';
     const createCache = options.createCache || defaultCreateCache;
 
     class Wrapper extends React.Component {

--- a/src/lib/GoogleApi.js
+++ b/src/lib/GoogleApi.js
@@ -11,7 +11,7 @@ export const GoogleApi = function(opts) {
     const client = opts.client;
     const URL = 'https://maps.googleapis.com/maps/api/js';
 
-    const googleVersion = opts.version || '3.24';
+    const googleVersion = opts.version || '3';
 
     let script = null;
     let google = window.google || null;


### PR DESCRIPTION
Specifying a retired version, such as `v=3.24`, will return the current frozen version and show a warning. Specifying `v=3` will return the current release version instead. More info [here](https://developers.google.com/maps/documentation/javascript/versions).