### PR TITLE
(fix) Add gestureHandling prop to Map component (Closes #46)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,8 @@ export class Map extends React.Component {
           keyboardShortcuts: this.props.keyboardShortcuts,
           disableDoubleClickZoom: this.props.disableDoubleClickZoom,
           noClear: this.props.noClear,
-          styles: this.props.styles
+          styles: this.props.styles,
+          gestureHandling: this.props.gestureHandling
         });
 
         Object.keys(mapConfig).forEach((key) => {
@@ -269,7 +270,8 @@ Map.propTypes = {
   keyboardShortcuts: T.bool,
   disableDoubleClickZoom: T.bool,
   noClear: T.bool,
-  styles: T.array
+  styles: T.array,
+  gestureHandling: T.string
 }
 
 evtNames.forEach(e => Map.propTypes[camelize(e)] = T.func)


### PR DESCRIPTION
This prop allows the gestureHandling option to be modified on the Google Map instance. All tests pass.