### PR TITLE
Include code dirs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
     "type": "git",
     "url": "https://github.com/fullstackreact/google-maps-react.git"
   },
+  "files": [
+    "dist",
+    "lib",
+    "src"
+  ]
   "main": "dist/index.js",
   "scripts": {
     "preversion": ". ./scripts/prepublish.sh",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dist",
     "lib",
     "src"
-  ]
+  ],
   "main": "dist/index.js",
   "scripts": {
     "preversion": ". ./scripts/prepublish.sh",


### PR DESCRIPTION
The current master branch does not include the src dir, which means npm installs sourcing git repos will fail.

edit: Sorry, sent this to the wrong target while testing something.