### PR TITLE
Remove string constraint on Marker icon because it should accept obje…

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ To place a marker on the Map, include it as a child of the `<Map />` component.
     name={'Dolores park'}
     position={{lat: 37.759703, lng: -122.428093}} />
   <Marker />
+  <Marker
+    name={'Your position'}
+    position={{lat: 37.762391, lng: -122.439192}}
+    icon={{
+      url: "/path/to/custom_icon.png",
+      anchor: new google.maps.Point(32,32),
+      scaledSize: new google.maps.Size(64,64)
+    }}
 </Map>
 ```
 
@@ -303,7 +311,7 @@ npm install
 make dev
 ```
 
-The Google Map React component library uses React and the Google API to give easy access to the Google Maps library. 
+The Google Map React component library uses React and the Google API to give easy access to the Google Maps library.
 
 ___
 
@@ -323,4 +331,3 @@ This app is only one of several apps we have in the book. If you're looking to l
 
 ## License
  [MIT](/LICENSE)
-

--- a/src/components/Marker.js
+++ b/src/components/Marker.js
@@ -87,8 +87,7 @@ export class Marker extends React.Component {
 
 Marker.propTypes = {
   position: T.object,
-  map: T.object,
-  icon: T.string
+  map: T.object
 }
 
 evtNames.forEach(e => Marker.propTypes[e] = T.func)


### PR DESCRIPTION
Icons can be added using an object description
```
icon={{
    url: "/img/target.svg",
    anchor: new google.maps.Point(40,40),
    scaledSize: new google.maps.Size(80,80)
}}
```

This works well but the console shows a warning:

> Failed prop type: Invalid prop `icon` of type `object` supplied to `Marker`, expected `string`.

And indeed, there's was a string proptype constraint in the Marker class.