### PR TITLE
Check if child is null before cloning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -218,6 +218,7 @@ export class Map extends React.Component {
       if (!children) return;
 
       return React.Children.map(children, c => {
+		if (!c) return;
         return React.cloneElement(c, {
           map: this.map,
           google: this.props.google,


### PR DESCRIPTION
This fixes an error I'm getting when adding children to the Map conditionally. If the Map children array contains null or undefined elements, the cloneElement function fails. Checking before cloning solves it.

Full story:
I have a Marker and a custom Circle component I'm adding to the map, conditionally. Something like

```
render: function() {
    let marker = null;
    if (this.state.lat && this.state.lng) {
        marker = (
            <Marker name={'marker'}
                    position={{lat: this.state.currentLat, lng: this.state.currentLng}} />);
    }

    let circle = null;
    if (this.state.lat && this.state.lng && this.props.radius) {
        circle = (
            <Circle [...] />);
    }

    return (
        <div className="some-class">
            <Map ref='map' [...]>
            {circle}
            {marker}
            </Map>
    );
}

```
However, if one of these variables (marker and circle) is null, they show up as undefined items in the children array. Then the renderChildren function attempts to clone them and when cloneElement attempts to access it's props, it fails.

The renderChildren function checks if "children" exists, but not if each of them is null/undefined. I changed the function to check each one before cloning and now it works.