### PR TITLE
Extend marker mouse events

### DIFF
--- a/src/components/Marker.js
+++ b/src/components/Marker.js
@@ -1,7 +1,17 @@
 import React, { PropTypes as T } from 'react'
 
 import { camelize } from '../lib/String'
-const evtNames = ['click', 'mouseover', 'recenter', 'dragend'];
+
+const evtNames = [
+  'click',
+  'dblclick',
+  'dragend',
+  'mousedown',
+  'mouseout',
+  'mouseover',
+  'mouseup',
+  'recenter',
+];
 
 const wrappedPromise = function() {
     var wrappedPromise = {},

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ export class Map extends React.Component {
 
         Object.keys(mapConfig).forEach((key) => {
           // Allow to configure mapConfig with 'false'
-          if (mapConfig[key] == null) {
+          if (mapConfig[key] === null) {
             delete mapConfig[key];
           }
         });


### PR DESCRIPTION
Extended the mouse events that can be handled in the ``Marker`` component, as described here: https://developers.google.com/maps/documentation/javascript/events