### PR TITLE
Feature InfoWindow position

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ The `<InfoWindow />` component included in this library is gives us the ability 
 
 The visibility of the `<InfoWindow />` component is controlled by a `visible` prop. The `visible` prop is a boolean (`React.PropTypes.bool`) that shows the `<InfoWindow />` when true and hides it when false.
 
+There are two ways how to control a position of the `<InfoWindow />` component.
+You can use a `position` prop or connect the `<InfoWindow />` component directly to an existing `<Marker />` component by using a `marker` prop.
+
 ```javascript
 const WithMarkers = React.createClass({
   getInitialState: function() {

--- a/examples/components/clickableMarkers.js
+++ b/examples/components/clickableMarkers.js
@@ -68,6 +68,12 @@ const WithMarkers = React.createClass({
               <h1>{this.state.selectedPlace.name}</h1>
             </div>
         </InfoWindow>
+
+        <InfoWindow
+          position={{lat: 37.765703, lng: -122.425640}}
+          visible={true}>
+          <small>Click on any of the markers to display an additional info.</small>
+        </InfoWindow>
       </Map>
     )
   }

--- a/src/components/InfoWindow.js
+++ b/src/components/InfoWindow.js
@@ -19,12 +19,17 @@ export class InfoWindow extends React.Component {
       this.renderInfoWindow();
     }
 
+    if (this.props.position !== prevProps.position) {
+      this.updatePosition();
+    }
+
     if (this.props.children !== prevProps.children) {
       this.updateContent();
     }
 
     if ((this.props.visible !== prevProps.visible ||
-        this.props.marker !== prevProps.marker)) {
+        this.props.marker !== prevProps.marker ||
+        this.props.position !== prevProps.position)) {
         this.props.visible ?
           this.openWindow() :
           this.closeWindow();
@@ -64,6 +69,14 @@ export class InfoWindow extends React.Component {
     this.infowindow.open(this.props.map, this.props.marker);
   }
 
+  updatePosition() {
+    let pos = this.props.position;
+    if (!(pos instanceof google.maps.LatLng)) {
+      pos = pos && new google.maps.LatLng(pos.lat, pos.lng);
+    }
+    this.infowindow.setPosition(pos);
+  }
+
   updateContent() {
     const content = this.renderChildren();
     this.infowindow.setContent(content);
@@ -87,6 +100,7 @@ InfoWindow.propTypes = {
   children: T.element.isRequired,
   map: T.object,
   marker: T.object,
+  position: T.object,
   visible: T.bool,
 
   // callbacks


### PR DESCRIPTION
Hi, according to [google maps](https://developers.google.com/maps/documentation/javascript/infowindows) documentation, it should be possible to set the position of the InfoWindow component without using a marker.
