### PR TITLE
Moved to prop-types package for compatibility with React 15.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The `<InfoWindow />` component included in this library is gives us the ability 
 
 ![](http://d.pr/i/16w0V.png)
 
-The visibility of the `<InfoWindow />` component is controlled by a `visible` prop. The `visible` prop is a boolean (`React.PropTypes.bool`) that shows the `<InfoWindow />` when true and hides it when false.
+The visibility of the `<InfoWindow />` component is controlled by a `visible` prop. The `visible` prop is a boolean (`PropTypes.bool`) that shows the `<InfoWindow />` when true and hides it when false.
 
 ```javascript
 const WithMarkers = React.createClass({

--- a/examples/Container.js
+++ b/examples/Container.js
@@ -1,4 +1,5 @@
-import React, {PropTypes as T} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import {Link} from 'react-router'
 import GitHubForkRibbon from 'react-github-fork-ribbon'
@@ -15,11 +16,11 @@ import styles from './styles.module.css'
 export const Container = React.createClass({
 
   propTypes: {
-    children: T.element.isRequired
+    children: PropTypes.element.isRequired
   },
 
   contextTypes: {
-    router: T.object
+    router: PropTypes.object
   },
 
   renderChildren: function() {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "npm-font-open-sans": "0.0.3",
     "postcss-loader": "^0.9.1",
     "precss": "^1.4.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",

--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -1,4 +1,4 @@
-import React, {PropTypes as T} from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
 
 import {ScriptCache} from './lib/ScriptCache'

--- a/src/components/HeatMap.js
+++ b/src/components/HeatMap.js
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import { camelize } from '../lib/String'
 const evtNames = ['click', 'mouseover', 'recenter'];
@@ -91,12 +92,12 @@ export class HeatMap extends React.Component {
 }
 
 HeatMap.propTypes = {
-  position: T.object,
-  map: T.object,
-  icon: T.string
+  position: PropTypes.object,
+  map: PropTypes.object,
+  icon: PropTypes.string
 }
 
-evtNames.forEach(e => HeatMap.propTypes[e] = T.func)
+evtNames.forEach(e => HeatMap.propTypes[e] = PropTypes.func)
 
 HeatMap.defaultProps = {
   name: 'HeatMap'

--- a/src/components/InfoWindow.js
+++ b/src/components/InfoWindow.js
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import ReactDOMServer from 'react-dom/server'
 
@@ -84,14 +85,14 @@ export class InfoWindow extends React.Component {
 }
 
 InfoWindow.propTypes = {
-  children: T.element.isRequired,
-  map: T.object,
-  marker: T.object,
-  visible: T.bool,
+  children: PropTypes.element.isRequired,
+  map: PropTypes.object,
+  marker: PropTypes.object,
+  visible: PropTypes.bool,
 
   // callbacks
-  onClose: T.func,
-  onOpen: T.func
+  onClose: PropTypes.func,
+  onOpen: PropTypes.func
 }
 
 InfoWindow.defaultProps = {

--- a/src/components/Marker.js
+++ b/src/components/Marker.js
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import { camelize } from '../lib/String'
 const evtNames = ['click', 'mouseover', 'recenter', 'dragend'];
@@ -87,11 +88,11 @@ export class Marker extends React.Component {
 }
 
 Marker.propTypes = {
-  position: T.object,
-  map: T.object
+  position: PropTypes.object,
+  map: PropTypes.object
 }
 
-evtNames.forEach(e => Marker.propTypes[e] = T.func)
+evtNames.forEach(e => Marker.propTypes[e] = PropTypes.func)
 
 Marker.defaultProps = {
   name: 'Marker'

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, {PropTypes as T} from 'react';
+import React from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import { camelize } from './lib/String'
 import {makeCancelable} from './lib/cancelablePromise'
@@ -154,7 +155,7 @@ export class Map extends React.Component {
 
         Object.keys(mapConfig).forEach((key) => {
           // Allow to configure mapConfig with 'false'
-          if (mapConfig[key] == null) {
+          if (mapConfig[key] === null) {
             delete mapConfig[key];
           }
         });
@@ -246,36 +247,36 @@ export class Map extends React.Component {
 };
 
 Map.propTypes = {
-  google: T.object,
-  zoom: T.number,
-  centerAroundCurrentLocation: T.bool,
-  center: T.object,
-  initialCenter: T.object,
-  className: T.string,
-  style: T.object,
-  containerStyle: T.object,
-  visible: T.bool,
-  mapType: T.string,
-  maxZoom: T.number,
-  minZoom: T.number,
-  clickableIcons: T.bool,
-  disableDefaultUI: T.bool,
-  zoomControl: T.bool,
-  mapTypeControl: T.bool,
-  scaleControl: T.bool,
-  streetViewControl: T.bool,
-  panControl: T.bool,
-  rotateControl: T.bool,
-  scrollwheel: T.bool,
-  draggable: T.bool,
-  keyboardShortcuts: T.bool,
-  disableDoubleClickZoom: T.bool,
-  noClear: T.bool,
-  styles: T.array,
-  gestureHandling: T.string
+  google: PropTypes.object,
+  zoom: PropTypes.number,
+  centerAroundCurrentLocation: PropTypes.bool,
+  center: PropTypes.object,
+  initialCenter: PropTypes.object,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  containerStyle: PropTypes.object,
+  visible: PropTypes.bool,
+  mapType: PropTypes.string,
+  maxZoom: PropTypes.number,
+  minZoom: PropTypes.number,
+  clickableIcons: PropTypes.bool,
+  disableDefaultUI: PropTypes.bool,
+  zoomControl: PropTypes.bool,
+  mapTypeControl: PropTypes.bool,
+  scaleControl: PropTypes.bool,
+  streetViewControl: PropTypes.bool,
+  panControl: PropTypes.bool,
+  rotateControl: PropTypes.bool,
+  scrollwheel: PropTypes.bool,
+  draggable: PropTypes.bool,
+  keyboardShortcuts: PropTypes.bool,
+  disableDoubleClickZoom: PropTypes.bool,
+  noClear: PropTypes.bool,
+  styles: PropTypes.array,
+  gestureHandling: PropTypes.string
 }
 
-evtNames.forEach(e => Map.propTypes[camelize(e)] = T.func)
+evtNames.forEach(e => Map.propTypes[camelize(e)] = PropTypes.func)
 
 Map.defaultProps = {
   zoom: 14,


### PR DESCRIPTION
https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

"The biggest change is that we've extracted React.PropTypes and React.createClass into their own packages. Both are still accessible via the main React object, but using either will log a one-time deprecation warning to the console when in development mode."