### PR TITLE
Fix render crashing with null children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,11 +219,11 @@ export class Map extends React.Component {
       if (!children) return;
 
       return React.Children.map(children, c => {
-        return React.cloneElement(c, {
+        return c ? React.cloneElement(c, {
           map: this.map,
           google: this.props.google,
           mapCenter: this.state.currentLocation
-        });
+        }) : null;
       })
     }
 


### PR DESCRIPTION
Currently null children crashes with
```
ReactElement.js:271 Uncaught TypeError: Cannot read property 'props' of null
    at Object.ReactElement.cloneElement (ReactElement.js:271)
    at Object.cloneElement (ReactElementValidator.js:242)
    at index.js:315
    at mapSingleChildIntoContext (ReactChildren.js:107)
    at traverseAllChildrenImpl (traverseAllChildren.js:77)
    at traverseAllChildrenImpl (traverseAllChildren.js:93)
    at traverseAllChildren (traverseAllChildren.js:172)
    at mapIntoWithKeyPrefixInternal (ReactChildren.js:127)
    at Object.mapChildren [as map] (ReactChildren.js:149)
```