### PR TITLE
Check for react lifecycle status before calling setState.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/index');
+module.exports = require('./src/index');

--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -38,7 +38,7 @@ export const wrapper = (options) => (WrappedComponent) => {
 
         onLoad(err, tag) {
             this._gapi = window.google;
-
+            if (!this._reactInternalInstance) return;
             this.setState({loaded: true, google: this._gapi})
         }
 


### PR DESCRIPTION
Non-destructive fix for `setState` console warning on initializing markers:

```
Warning: setState(...): Can only update a mounted or mounting component. 
This usually means you called setState() on an unmounted component. 
This is a no-op. Please check the code for the Wrapper component.
``` 