### PR TITLE
Fixed Window Error for Isomorphic Applications Accessing GoogleApiWrapper

### DIFF
--- a/dist/lib/GoogleApi.js
+++ b/dist/lib/GoogleApi.js
@@ -39,7 +39,7 @@
         var googleVersion = opts.version || '3';
 
         var script = null;
-        var google = window.google || null;
+        var google = typeof window !== 'undefined' && window.google || null;
         var loading = false;
         var channel = null;
         var language = opts.language;


### PR DESCRIPTION
Fixes issue: https://github.com/fullstackreact/google-maps-react/issues/64
Relates to: https://github.com/fullstackreact/google-maps-react/issues/7  (closed, PR merged)

Description: 
For isomorphic applications trying to access GoogleApiWrapper the window object is not defined (see fixes issue link above). So an error is being formed. This PR addresses that error. 
There was a similar error in ScriptCache.js that was recently merged (see relates to link above).  