### PR TITLE
Update GoogleApiComponent.js

### DIFF
--- a/dist/GoogleApiComponent.js
+++ b/dist/GoogleApiComponent.js
@@ -83,7 +83,7 @@
         options = options || {};
         var apiKey = options.apiKey;
         var libraries = options.libraries || ['places'];
-        var version = options.version || '3.24';
+        var version = options.version || '3.28';
         var language = options.language || 'en';
 
         return (0, _ScriptCache.ScriptCache)({


### PR DESCRIPTION
fixes util.js:216 Google Maps API warning: RetiredVersion https://developers.google.com/maps/documentation/javascript/error-messages#retired-version