### PR TITLE
Add zIndex support for marker

### DIFF
--- a/dist/components/Marker.js
+++ b/dist/components/Marker.js
@@ -136,7 +136,9 @@
             icon = _props.icon,
             label = _props.label,
             draggable = _props.draggable,
-            title = _props.title;
+            title = _props.title,
+            optimized = _props.optimized,
+            zIndex = _props.zIndex;
 
         if (!google) {
           return null;
@@ -153,7 +155,9 @@
           icon: icon,
           label: label,
           title: title,
-          draggable: draggable
+          draggable: draggable,
+          optimized: optimized,
+          zIndex: zIndex
         };
         this.marker = new google.maps.Marker(pref);
 


### PR DESCRIPTION
1) Allow user to pass 'zIndex' and 'optimized' props to marker class. Setting the 'optimized' property to 'false' seems to help the user determine which marker displays on top using the zIndex property. See: https://stackoverflow.com/questions/11845916/google-maps-marker-zindex-doesnt-work-for-two-icon-types-symbol-and-string