### PR TITLE
Revert change from PR #126 to fix (again) #110

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,7 @@ export class Map extends React.Component {
           center: center,
           zoom: this.props.zoom,
           maxZoom: this.props.maxZoom,
-          minZoom: this.props.maxZoom,
+          minZoom: this.props.minZoom,
           clickableIcons: !!this.props.clickableIcons,
           disableDefaultUI: this.props.disableDefaultUI,
           zoomControl: this.props.zoomControl,


### PR DESCRIPTION
Revert change from PR #126 to fix option minZoom from props

https://github.com/fullstackreact/google-maps-react/commit/f626c208c3a8010cf547b3643c6557cde62ee588#diff-1fdf421c05c1140f6d71444ea2b27638R145