### PR TITLE
Allow GoogleApiWrapper() HOC to be initialized with data from props

### DIFF
--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -22,12 +22,14 @@ const defaultCreateCache = (options) => {
     });
 };
 
-export const wrapper = (options) => (WrappedComponent) => {
-    const createCache = options.createCache || defaultCreateCache;
+export const wrapper = (input) => (WrappedComponent) => {
 
     class Wrapper extends React.Component {
         constructor(props, context) {
             super(props, context);
+
+            const options = typeof input === 'function' ? input(props) : input;
+            const createCache = options.createCache || defaultCreateCache;
 
             this.scriptCache = createCache(options);
             this.scriptCache.google.onLoad(this.onLoad.bind(this))


### PR DESCRIPTION
This pull requests enhances the GoogleApiWrapper HOC by the possibility to initialize it with data from props by accepting a function as argument when initializing the HOC. The function will be called by the HOC by passing it the props passed to the HOC.

This solution inspired by the recompose bundle (e.g. the HOC [withProps()](https://github.com/acdlite/recompose/blob/master/docs/API.md#withprops)) and is **completely backwards compatible**. 

With this change, the GoogleApiWrapper can be used the same way as before:

```js
GoogleApiWrapper({
  apiKey: (YOUR_GOOGLE_API_KEY_GOES_HERE),
})(MapContainer)
```

Additionally it can be initialized with a function as described above:

```js
GoogleApiWrapper((props) => ({
  apiKey: props.apiKey,
  language: props.language,
}))(MapContainer)
```

Or, as in our case, the HOC can be used with redux and recompose:

```js
const mapStateToProps = (state) => ({
	lang: selectLang(state),
})

const enhance = compose(
	connect(mapStateToProps),
	GoogleApiWrapper(({ lang }) => ({
		apiKey: 'API_KEY',
		language: lang,
	})),
)

export default enhance(MapContainer)
```
