### PR TITLE
Add 'client' argument (Update GoogleApiComponent.js)

### DIFF
--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -16,6 +16,7 @@ const defaultCreateCache = options => {
   const version = options.version || '3';
   const language = options.language || 'en';
   const url = options.url;
+  const client = options.client;
 
   return ScriptCache({
     google: GoogleApi({
@@ -23,7 +24,8 @@ const defaultCreateCache = options => {
       language: language,
       libraries: libraries,
       version: version,
-      url: url
+      url: url,
+      client: client
     })
   });
 };


### PR DESCRIPTION
Adds 'client' argument into 'ScriptCache' call. This is useful to load Google Maps API when you only have clientID  (Google's Premium Plan users). 