### PR TITLE
Server side rendering fixes for Gatsby.

### DIFF
--- a/dist/lib/GoogleApi.js
+++ b/dist/lib/GoogleApi.js
@@ -39,7 +39,7 @@
     var googleVersion = opts.version || '3.31';
 
     var script = null;
-    var google = window.google || null;
+    var google = typeof window !== 'undefined' && window.google || null;
     var loading = false;
     var channel = null;
     var language = opts.language;

--- a/dist/lib/ScriptCache.js
+++ b/dist/lib/ScriptCache.js
@@ -51,6 +51,10 @@
 
             Cache._scriptTag = function (key, src) {
                 if (!scriptMap.has(key)) {
+                    // Server side rendering environments don't always have access to the `document` global.
+                    // In these cases, we're not going to be able to return a script tag, so just return null.
+                    if (typeof document === 'undefined') return null;
+
                     var tag = document.createElement('script');
                     var promise = new Promise(function (resolve, reject) {
                         var resolved = false,

--- a/src/lib/GoogleApi.js
+++ b/src/lib/GoogleApi.js
@@ -16,7 +16,7 @@ export const GoogleApi = function(opts) {
   const googleVersion = opts.version || '3.31';
 
   let script = null;
-  let google = window.google || null;
+  let google = typeof window !== 'undefined' && window.google || null;
   let loading = false;
   let channel = null;
   let language = opts.language;

--- a/src/lib/ScriptCache.js
+++ b/src/lib/ScriptCache.js
@@ -35,6 +35,10 @@ export const ScriptCache = (function(global) {
 
         Cache._scriptTag = (key, src) => {
             if (!scriptMap.has(key)) {
+                // Server side rendering environments don't always have access to the `document` global.
+                // In these cases, we're not going to be able to return a script tag, so just return null.
+                if (typeof document === 'undefined') return null;
+
                 let tag = document.createElement('script');
                 let promise = new Promise((resolve, reject) => {
                     let resolved = false,


### PR DESCRIPTION
We're trying to use this module with Gatsby and found that it fails to build because it sometimes assumes the existence of both `document` and `window`.

These two fixes make it so it works in Gatsby. If you have any questions or there's a better way to do this, just let me know. Thanks!