### PR TITLE
Accept region as an optional param

### DIFF
--- a/src/lib/GoogleApi.js
+++ b/src/lib/GoogleApi.js
@@ -20,7 +20,7 @@ export const GoogleApi = function(opts) {
   let loading = false;
   let channel = null;
   let language = opts.language;
-  let region = null;
+  let region = opts.region || null;
 
   let onLoadEvents = [];
 


### PR DESCRIPTION
Enable searching in a specific region by passing the region to the API. 
Currently `region` is defaulted as `null`.

Something like this:
```
export default GoogleApiWrapper({
  apiKey: MY_API_KEY,
  region: 'NZ'
})(MY_COMPONENT)
```