### PR TITLE
Expose fitBounds() on Map component

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,31 @@ center: Takes an object containing latitude and longitude coordinates. Use this 
           onClick={this.onMapClicked}
         >
 ```
+bounds:  Takes a [google.maps.LatLngBounds()](https://developers.google.com/maps/documentation/javascript/reference/3/#LatLngBounds) object to adjust the center and zoom of the map.
+```javascript
+var points = [
+    { lat: 42.02, lng: -77.01 },
+    { lat: 42.03, lng: -77.02 },
+    { lat: 41.03, lng: -77.04 },
+    { lat: 42.05, lng: -77.02 }
+]
+var bounds = new this.props.google.maps.LatLngBounds();
+for (var i = 0; i < points.length; i++) {
+  bounds.extend(points[i]);
+}
+return (
+    <Map
+        google={this.props.google}
+        initialCenter={{
+            lat: 42.39,
+            lng: -72.52
+        }}
+        bounds={bounds}>
+    </Map>
+);
+
+```
+
 It also takes event handlers described below:
 
 ### Events

--- a/dist/index.js
+++ b/dist/index.js
@@ -199,6 +199,9 @@
         if (prevState.currentLocation !== this.state.currentLocation) {
           this.recenterMap();
         }
+        if (this.props.bounds !== prevProps.bounds) {
+          this.map.fitBounds(this.props.bounds);
+        }
       }
     }, {
       key: 'componentWillUnmount',
@@ -394,7 +397,8 @@
     disableDoubleClickZoom: _propTypes2.default.bool,
     noClear: _propTypes2.default.bool,
     styles: _propTypes2.default.array,
-    gestureHandling: _propTypes2.default.string
+    gestureHandling: _propTypes2.default.string,
+    bounds: _propTypes2.default.object
   };
 
   evtNames.forEach(function (e) {

--- a/dist/lib/GoogleApi.js
+++ b/dist/lib/GoogleApi.js
@@ -43,7 +43,7 @@
     var loading = false;
     var channel = null;
     var language = opts.language;
-    var region = null;
+    var region = opts.region || null;
 
     var onLoadEvents = [];
 

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,9 @@ export class Map extends React.Component {
     if (prevState.currentLocation !== this.state.currentLocation) {
       this.recenterMap();
     }
+    if (this.props.bounds !== prevProps.bounds) {
+      this.map.fitBounds(this.props.bounds);
+    }
   }
 
   componentWillUnmount() {
@@ -288,7 +291,8 @@ Map.propTypes = {
   disableDoubleClickZoom: PropTypes.bool,
   noClear: PropTypes.bool,
   styles: PropTypes.array,
-  gestureHandling: PropTypes.string
+  gestureHandling: PropTypes.string,
+  bounds: PropTypes.object
 };
 
 evtNames.forEach(e => (Map.propTypes[camelize(e)] = PropTypes.func));


### PR DESCRIPTION
Fixes #183 

This allows the map to be centered to fit a polyline, by passing a bounds prop to the map.
I tested locally building on top of pull request #203 so probably merge that one first. 

The commit "Accept region as option param" got caught up in here because the dist was not committed.