### PR TITLE
Adding channel option/param for Google URL

### DIFF
--- a/src/lib/GoogleApi.js
+++ b/src/lib/GoogleApi.js
@@ -15,7 +15,7 @@ export const GoogleApi = function(opts) {
   let script = null;
   let google = (typeof window !== 'undefined' && window.google) || null;
   let loading = false;
-  let channel = null;
+  let channel = opts.channel;
   let language = opts.language;
   let region = opts.region || null;
 


### PR DESCRIPTION
This option / parameter of the channel is used to concatenate it when the component creates the URL to obtain the Google API, this parameter groups the use of resources using the same API_KEY between the different applications.