### PR TITLE
add custom className support for the top level element 

### DIFF
--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -96,6 +96,8 @@ export const wrapper = input => WrappedComponent => {
       // Store information about loading container
       this.LoadingContainer =
         options.LoadingContainer || DefaultLoadingContainer;
+      // add custom className to the top div
+      this.wrapperClassName = options.wrapperClassName || '';
     }
 
     onLoad(err, tag) {
@@ -116,7 +118,7 @@ export const wrapper = input => WrappedComponent => {
       });
 
       return (
-        <div>
+        <div className={this.wrapperClassName}>
           <WrappedComponent {...props} />
           <div ref="map" />
         </div>


### PR DESCRIPTION
add custom className support for the top level element 
at the moment, everything is being wrapped in a div without any props. that makes it impossible to access properly for styling.