### PR TITLE
The examples of Polygon and Polyline are using incorrect property

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ render() {
         className={'map'}
         zoom={14}>
         <Polygon
-          paths={triangleCoords}
+          path={triangleCoords}
           strokeColor="#0000FF"
           strokeOpacity={0.8}
           strokeWeight={2}
@@ -368,7 +368,7 @@ render() {
         className={'map'}
         zoom={14}>
         <Polyline
-          paths={triangleCoords}
+          path={triangleCoords}
           strokeColor="#0000FF"
           strokeOpacity={0.8}
           strokeWeight={2} />


### PR DESCRIPTION
It should be `path` and not `paths`.
When copy-pasting from the docs, the example does not work.