### PR TITLE
Zoom and Street View controls position

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,9 @@ export class Map extends React.Component {
           disableDoubleClickZoom: this.props.disableDoubleClickZoom,
           noClear: this.props.noClear,
           styles: this.props.styles,
-          gestureHandling: this.props.gestureHandling
+          gestureHandling: this.props.gestureHandling,
+          streetViewControlOptions:this.props.streetViewControlOptions,
+          zoomControlOptions:this.props.zoomControlOptions
         }
       );
 
@@ -290,7 +292,9 @@ Map.propTypes = {
   noClear: PropTypes.bool,
   styles: PropTypes.array,
   gestureHandling: PropTypes.string,
-  bounds: PropTypes.object
+  bounds: PropTypes.object,
+  streetViewControlOptions:PropTypes.object,
+  zoomControlOptions:PropTypes.object
 };
 
 evtNames.forEach(e => (Map.propTypes[camelize(e)] = PropTypes.func));


### PR DESCRIPTION
Added the capability to change the default position of the zoom control and street view control.
Control names are those from the google-maps API.
Example : Add them to the map component and pass them an object as follow :

<Map 
google={this.props.google}
zoom={5}
style={{ height: '80%' }}
initialCenter={{lat: 47.4840791,lng: 5.683411}}
zoomControl={true}
streetViewControl={true}
streetViewControlOptions={{position: google.maps.ControlPosition.LEFT_TOP}}
zoomControlOptions= {{position :google.maps.ControlPosition.LEFT_TOP}}
>