### PR TITLE
Fixing link to example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export default GoogleApiWrapper({
 
 ## Examples
 
-Check out the example site at: [http://fullstackreact.github.io/google-maps-react](fullstackreact.github.io/google-maps-react)
+Check out the example site at: [http://fullstackreact.github.io/google-maps-react](http://fullstackreact.github.io/basic)
 
 ## Additional Map Props
 The Map component takes a number of optional props.


### PR DESCRIPTION
The link to the example on README is missing the `http://` part and because of that, it leads to the wrong destination.

correct destination: http://fullstackreact.github.io/basic
wrong destination: https://github.com/fullstackreact/google-maps-react/blob/master/fullstackreact.github.io/google-maps-react