### PR TITLE
polyline documentation fix [README.md]

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ render() {
         className={'map'}
         zoom={14}>
         <Polyline
-          paths={triangleCoords}
+          path={triangleCoords}
           strokeColor="#0000FF"
           strokeOpacity={0.8}
           strokeWeight={2} />


### PR DESCRIPTION
In documentation there is prop named paths in polyline component, but it needs to be path.