### PR TITLE
Add an error call back param

### DIFF
--- a/src/lib/GoogleApi.js
+++ b/src/lib/GoogleApi.js
@@ -32,7 +32,7 @@ export const GoogleApi = function(opts) {
       channel: channel,
       language: language,
       region: region,
-      onError: 'ERROR_FUNCTION'
+      onerror: 'ERROR_FUNCTION'
     };
 
     let paramStr = Object.keys(params)

--- a/src/lib/GoogleApi.js
+++ b/src/lib/GoogleApi.js
@@ -31,7 +31,8 @@ export const GoogleApi = function(opts) {
       v: googleVersion,
       channel: channel,
       language: language,
-      region: region
+      region: region,
+      onError: 'ERROR_FUNCTION'
     };
 
     let paramStr = Object.keys(params)


### PR DESCRIPTION
This allows you to set an onError callback function in case the map doesn't load correctly.