### PR TITLE
Adding support for InfoWindow as a prop child of Marker

### DIFF
--- a/src/components/Marker.js
+++ b/src/components/Marker.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Fragment} from 'react'
 import PropTypes from 'prop-types'
 
 import { camelize } from '../lib/String'
@@ -104,7 +104,20 @@ export class Marker extends React.Component {
   }
 
   render() {
-    return null;
+    return (
+      <Fragment>
+        {this.props.children && this.marker ?
+          React.Children.only(
+            React.cloneElement(
+              this.props.children, 
+              { marker: this.marker,
+                google: this.props.google,
+                map: this.props.map}
+            )
+          ) : null
+        }
+      </Fragment>
+    )
   }
 }
 


### PR DESCRIPTION
Let's say you want to a simple map with 1 marker and you want to have an InfoWindow open when the component renders. For example, you want a location and you want to show some details about the location in an InfoWindow. InfoWindow requires either a position or a marker, but if you use the position, it will be laid on top of the marker. 

This change allows the InfoWindow to be passed as a child inside of the Marker and passes on the Marker's marker, google and map to the child. Example:

```
         <Marker
            title="Location"
            id={1}
            position={markerCenter}
            draggable={true}
            onDragend={this.moveMarker.bind(this)}
            >
            <InfoWindow
              visible={showInfoWindow}
              style={styles.infoWindow}
              >
                <div className={classes.infoWindow}>
                  <p>Click on the map or drag the marker to select location where the incident occurred</p>
                </div>
            </InfoWindow>
          </Marker>