### PR TITLE
Underscore event props

### DIFF
--- a/dist/lib/String.js
+++ b/dist/lib/String.js
@@ -17,7 +17,7 @@
     value: true
   });
   var camelize = exports.camelize = function camelize(str) {
-    return str.split(' ').map(function (word) {
+    return str.split('_').map(function (word) {
       return word.charAt(0).toUpperCase() + word.slice(1);
     }).join('');
   };

--- a/src/lib/String.js
+++ b/src/lib/String.js
@@ -1,5 +1,5 @@
 export const camelize = function(str) {
-  return str.split(' ').map(function(word) {
+  return str.split('_').map(function(word) {
     return word.charAt(0).toUpperCase() + word.slice(1);
   }).join('');
 }


### PR DESCRIPTION
Quick fix for prop event names with underscores
i.e. `bounds changed` becomes `Bounds_changed` with current camelize, so prop name has to be `onBounds_changed`.
This fixes it so that the prop name will be `onBoundsChanged`