### PR TITLE
Remove absolute div container from package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,12 @@ import {makeCancelable} from './lib/cancelablePromise';
 
 const mapStyles = {
   container: {
-    position: 'absolute',
-    width: '100%',
-    height: '100%'
+    // position: 'absolute',
+    // width: '100%',
+    // height: '100%'
   },
   map: {
-    position: 'absolute',
+    // position: 'absolute',
     left: 0,
     right: 0,
     bottom: 0,


### PR DESCRIPTION
The generated container makes it difficult for users to set custom map sizes. Current PR has old code commented out. If you would like it removed let me know.

This:
![screen shot 2018-11-20 at 7 49 25 pm](https://user-images.githubusercontent.com/21270054/48817941-9c6bed80-ecfd-11e8-922d-6d7a121a1072.png)

Versus:
![screen shot 2018-11-20 at 7 50 26 pm](https://user-images.githubusercontent.com/21270054/48817948-a261ce80-ecfd-11e8-8a5d-f9ba134fdb43.png)
