### PR TITLE
include types in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
We have the `index.d.ts` file in this repo, but without including it in the `files` array it is not included in the distributed package. If this PR is merged it means typescript users will not need to do `npm install @types/google-maps-react`.