### PR TITLE
mark package as tree shakeable

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "index.d.ts"
   ],
   "types": "index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "prepublish": "./scripts/prepublish.sh",
     "preversion": ". ./scripts/prepublish.sh",


### PR DESCRIPTION
this allows for more advanced DCE of components that aren't being used, e.g. if you don't use `InfoWindow` no need to include it in the bundle

https://github.com/webpack/webpack/tree/master/examples/side-effects