### PR TITLE
Include native controlSize attribute to Map props #339

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,8 @@ export class Map extends React.Component {
           disableDoubleClickZoom: this.props.disableDoubleClickZoom,
           noClear: this.props.noClear,
           styles: this.props.styles,
-          gestureHandling: this.props.gestureHandling
+          gestureHandling: this.props.gestureHandling,
+          controlSize: this.props.controlSize
         }
       );
 
@@ -299,7 +300,8 @@ Map.propTypes = {
   noClear: PropTypes.bool,
   styles: PropTypes.array,
   gestureHandling: PropTypes.string,
-  bounds: PropTypes.object
+  bounds: PropTypes.object,
+  controlSize: PropTypes.number
 };
 
 evtNames.forEach(e => (Map.propTypes[camelize(e)] = PropTypes.func));


### PR DESCRIPTION
PR matches the issue title => https://github.com/fullstackreact/google-maps-react/issues/339
I've checked for any references to this specific attr, and I believe this is the first PR addressing this functionality  