### PR TITLE
Updated polyline and polygon to re-render on props change

### DIFF
--- a/dist/components/Polygon.js
+++ b/dist/components/Polygon.js
@@ -135,7 +135,7 @@
     }, {
       key: 'componentDidUpdate',
       value: function componentDidUpdate(prevProps) {
-        if (this.props.map !== prevProps.map || !(0, _arePathsEqual.arePathsEqual)(this.props.paths, prevProps.paths)) {
+        if (this.propsChanged(prevProps) || this.props.map !== prevProps.map || !(0, _arePathsEqual.arePathsEqual)(this.props.paths, prevProps.paths)) {
           if (this.polygon) {
             this.polygon.setMap(null);
           }
@@ -150,9 +150,18 @@
         }
       }
     }, {
+      key: 'propsChanged',
+      value: function propsChanged(newProps) {
+        var _this2 = this;
+
+        return Object.keys(Polygon.propTypes).some(function (key) {
+          return _this2.props[key] !== newProps[key];
+        });
+      }
+    }, {
       key: 'renderPolygon',
       value: function renderPolygon() {
-        var _this2 = this;
+        var _this3 = this;
 
         var _props = this.props,
             map = _props.map,
@@ -182,7 +191,7 @@
         this.polygon = new google.maps.Polygon(params);
 
         evtNames.forEach(function (e) {
-          _this2.polygon.addListener(e, _this2.handleEvent(e));
+          _this3.polygon.addListener(e, _this3.handleEvent(e));
         });
 
         this.polygonPromise.resolve(this.polygon);
@@ -195,12 +204,12 @@
     }, {
       key: 'handleEvent',
       value: function handleEvent(evt) {
-        var _this3 = this;
+        var _this4 = this;
 
         return function (e) {
           var evtName = 'on' + (0, _String.camelize)(evt);
-          if (_this3.props[evtName]) {
-            _this3.props[evtName](_this3.props, _this3.polygon, e);
+          if (_this4.props[evtName]) {
+            _this4.props[evtName](_this4.props, _this4.polygon, e);
           }
         };
       }

--- a/dist/components/Polyline.js
+++ b/dist/components/Polyline.js
@@ -135,7 +135,7 @@
     }, {
       key: 'componentDidUpdate',
       value: function componentDidUpdate(prevProps) {
-        if (this.props.map !== prevProps.map || !(0, _arePathsEqual.arePathsEqual)(this.props.path, prevProps.path)) {
+        if (this.propsChanged(prevProps) || this.props.map !== prevProps.map || !(0, _arePathsEqual.arePathsEqual)(this.props.path, prevProps.path)) {
           if (this.polyline) {
             this.polyline.setMap(null);
           }
@@ -150,9 +150,18 @@
         }
       }
     }, {
+      key: 'propsChanged',
+      value: function propsChanged(newProps) {
+        var _this2 = this;
+
+        return Object.keys(Polyline.propTypes).some(function (key) {
+          return _this2.props[key] !== newProps[key];
+        });
+      }
+    }, {
       key: 'renderPolyline',
       value: function renderPolyline() {
-        var _this2 = this;
+        var _this3 = this;
 
         var _props = this.props,
             map = _props.map,
@@ -178,7 +187,7 @@
         this.polyline = new google.maps.Polyline(params);
 
         evtNames.forEach(function (e) {
-          _this2.polyline.addListener(e, _this2.handleEvent(e));
+          _this3.polyline.addListener(e, _this3.handleEvent(e));
         });
 
         this.polylinePromise.resolve(this.polyline);
@@ -191,12 +200,12 @@
     }, {
       key: 'handleEvent',
       value: function handleEvent(evt) {
-        var _this3 = this;
+        var _this4 = this;
 
         return function (e) {
           var evtName = 'on' + (0, _String.camelize)(evt);
-          if (_this3.props[evtName]) {
-            _this3.props[evtName](_this3.props, _this3.polyline, e);
+          if (_this4.props[evtName]) {
+            _this4.props[evtName](_this4.props, _this4.polyline, e);
           }
         };
       }

--- a/src/components/Polygon.js
+++ b/src/components/Polygon.js
@@ -26,6 +26,7 @@ export class Polygon extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (
+      this.propsChanged(prevProps) ||
       this.props.map !== prevProps.map ||
       !arePathsEqual(this.props.paths, prevProps.paths)
     ) {
@@ -41,6 +42,12 @@ export class Polygon extends React.Component {
       this.polygon.setMap(null);
     }
   }
+
+  propsChanged(newProps) {
+    return Object.keys(Polygon.propTypes).some(key => (
+      this.props[key] !== newProps[key]
+    ));
+  };
 
   renderPolygon() {
     const {

--- a/src/components/Polyline.js
+++ b/src/components/Polyline.js
@@ -27,6 +27,7 @@ export class Polyline extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (
+      this.propsChanged(prevProps) ||
       this.props.map !== prevProps.map ||
       !arePathsEqual(this.props.path, prevProps.path)
     ) {
@@ -42,6 +43,12 @@ export class Polyline extends React.Component {
       this.polyline.setMap(null);
     }
   }
+
+  propsChanged(newProps) {
+    return Object.keys(Polyline.propTypes).some(key => (
+      this.props[key] !== newProps[key]
+    ));
+  };
 
   renderPolyline() {
     const {


### PR DESCRIPTION
Previously polygons/polylines weren't checking the props to see if they need to re-render when component did update.

Added in propChanged function, similar to the way circle is handled in commit: c5de2a7f8efbd50a933a2415756ccef10dc65660