### PR TITLE
Handle underscore events

### DIFF
--- a/dist/lib/String.js
+++ b/dist/lib/String.js
@@ -17,7 +17,7 @@
     value: true
   });
   var camelize = exports.camelize = function camelize(str) {
-    return str.split(' ').map(function (word) {
+    return str.split('_').map(function (word) {
       return word.charAt(0).toUpperCase() + word.slice(1);
     }).join('');
   };

--- a/src/lib/String.js
+++ b/src/lib/String.js
@@ -1,5 +1,5 @@
 export const camelize = function(str) {
-  return str.split(' ').map(function(word) {
+  return str.split('_').map(function(word) {
     return word.charAt(0).toUpperCase() + word.slice(1);
   }).join('');
 }


### PR DESCRIPTION
This was already solved in https://github.com/fullstackreact/google-maps-react/pull/278
Somehow it was removed by one of the commits in https://github.com/fullstackreact/google-maps-react/pull/280, even though the diff does not show it as a change.

This is to get it back in so that the already solved problem of multi-word events (i.e. `bounds_changed`) are properly mapped to multi-word prop names. (i.e. `onBoundsChanged` instead of `onBounds_changed`