### PR TITLE
FIX: removed duplicate `draggableCursor` prop in `loadMap`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -267,7 +267,6 @@
               noClear: this.props.noClear,
               styles: this.props.styles,
               gestureHandling: this.props.gestureHandling,
-              draggableCursor: this.props.draggableCursor,
               draggingCursor: this.props.draggingCursor
             });
   


### PR DESCRIPTION
Presence of multiple definitions isn't allowed in `strict-mode`. On lines 411 and 418 of `index.js`'s `loadMap` method, the `draggableCursor` `config` key is set twice, with the same `_propTypes2.default.string` value. 