### PR TITLE
Fix: Unregister load handler on unmount of Google API component

### DIFF
--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -79,6 +79,12 @@ export const wrapper = input => WrappedComponent => {
         google: null
       });
     }
+    
+    componentWillUnmount() {
+      if (this.unregisterLoadHandler) {
+        this.unregisterLoadHandler();
+      }  
+    }
 
     initialize(options) {
       // Avoid race condition: remove previous 'load' listener


### PR DESCRIPTION
Adds component will unmount to `GoogleApiComponent` - closes #248