### PR TITLE
onOpen() and onClose() pass props

### DIFF
--- a/src/components/InfoWindow.js
+++ b/src/components/InfoWindow.js
@@ -62,13 +62,13 @@ export class InfoWindow extends React.Component {
 
   onOpen() {
     if (this.props.onOpen) {
-      this.props.onOpen();
+      this.props.onOpen(this.props);
     }
   }
 
   onClose() {
     if (this.props.onClose) {
-      this.props.onClose();
+      this.props.onClose(this.props);
     }
   }
 


### PR DESCRIPTION
By letting onOpen() and onClose() pass this.props to the callback, the originating InfoWindow can be identified by props passed to it. This allows multiple InfoWindows to be used.