### PR TITLE
Fix deprecation message for componentWillReceiveProps 

### DIFF
--- a/src/GoogleApiComponent.js
+++ b/src/GoogleApiComponent.js
@@ -53,7 +53,7 @@ export const wrapper = input => WrappedComponent => {
       };
     }
 
-    componentWillReceiveProps(props) {
+    UNSAFE_componentWillReceiveProps(props) {
       // Do not update input if it's not dynamic
       if (typeof input !== 'function') {
         return;


### PR DESCRIPTION
Addresses the new warning returned by the new react version:

Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: GoogleMap

nothing fancy - just a straight line run of `npx react-codemod rename-unsafe-lifecycles`

