### PR TITLE
Add controls props into declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,6 +62,13 @@ export interface IMapProps extends google.maps.MapOptions {
   onTilesloaded?: mapEventHandler
   onTiltChanged?: mapEventHandler
   onZoomChanged?: mapEventHandler
+
+  streetViewControl?: boolean
+  fullscreenControl?: boolean
+  mapTypeControl?: boolean
+  rotateControl?: boolean
+  scaleControl?: boolean
+  zoomControl?: boolean
 }
 
 type markerEventHandler = (props?: IMarkerProps, marker?: google.maps.Marker, event?) => any


### PR DESCRIPTION
[Controls](https://developers.google.com/maps/documentation/javascript/controls#Adding_Controls_to_the_Map) were skipped in the declaration file