### PR TITLE
Add zoom property to IMapProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,8 @@ export interface IMapProps extends google.maps.MapOptions {
   center?: google.maps.LatLngLiteral
 
   visible?: boolean
+  
+  zoom?: number
 
   onReady?: mapEventHandler
   onClick?: mapEventHandler


### PR DESCRIPTION
Resolves #443

`zoom` is missing from the props, causing a type error to appear.