### PR TITLE
Add more event listener for Marker

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,12 @@ export interface IMarkerProps extends Partial<google.maps.MarkerOptions> {
 
   onClick?: markerEventHandler
   onMouseover?: markerEventHandler
+  onDblclick?: markerEventHandler
+  onDragend?: markerEventHandler
+  onMousedown?: markerEventHandler
+  onMouseout?: markerEventHandler
+  onMouseup?: markerEventHandler
+  onRecenter?: markerEventHandler
 }
 
 export class Map extends React.Component<IMapProps, any> {


### PR DESCRIPTION
Based on this code, the Marker can accept some more event listener. However, only `onClick` and `onMouseover` are listed on typescript definition.

https://github.com/fullstackreact/google-maps-react/blob/5038ac47b22682b12adfe18443ec617b2309f3c6/src/components/Marker.js#L97-L104
