### PR TITLE
Add zoom and Controls to IMapProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,15 @@ export interface IMapProps extends google.maps.MapOptions {
   centerAroundCurrentLocation?: boolean
   initialCenter?: google.maps.LatLngLiteral
   center?: google.maps.LatLngLiteral
+  zoom?: boolean
+
+  zoomControl?: boolean
+  mapTypeControl?: boolean
+  scaleControl?: boolean
+  streetViewControl?: boolean
+  panControl?: boolean
+  rotateControl?: boolean
+  fullscreenControl?: boolean
 
   visible?: boolean
 


### PR DESCRIPTION
Resolves #443

```zoom``` and [```Controls```](https://developers.google.com/maps/documentation/javascript/controls) are missing from the props, causing a type error to appear.
So I added type definition,  albeit a small change.