### PR TITLE
Add onDragend to IMarkerProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,7 @@ export interface IMarkerProps extends Partial<google.maps.MarkerOptions> {
 
   onClick?: markerEventHandler
   onMouseover?: markerEventHandler
+  onDragend?: markerEventHandler
 }
 
 export class Map extends React.Component<IMapProps, any> {


### PR DESCRIPTION
Here is an example from the repo.
![image](https://user-images.githubusercontent.com/7184368/127041286-8a68a634-44a9-4cd7-8fe5-6d2b42480730.png)

Since `onDragend` is not defined, this example will cause a compile error in TS.