### PR TITLE
Support for Restricting Map Bounds via restriction prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ export interface IMapProps extends google.maps.MapOptions {
   centerAroundCurrentLocation?: boolean
   initialCenter?: google.maps.LatLngLiteral
   center?: google.maps.LatLngLiteral
+  restriction?: google.maps.MapRestriction
   zoom?: number
 
   zoomControl?: boolean

--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,7 @@ export class Map extends React.Component {
           streetViewControlOptions: this.props.streetViewControlOptions,
           panControl: this.props.panControl,
           rotateControl: this.props.rotateControl,
+          restriction: this.props.restriction,
           fullscreenControl: this.props.fullscreenControl,
           scrollwheel: this.props.scrollwheel,
           draggable: this.props.draggable,


### PR DESCRIPTION
In order to support restriction on your map, the restriction prop must be allowed to be filled in.

See more about restriction:
https://developers.google.com/maps/documentation/javascript/examples/control-bounds-restriction
